### PR TITLE
Fixed typo.

### DIFF
--- a/config/windows_hayabusa_rules.yaml
+++ b/config/windows_hayabusa_rules.yaml
@@ -638,7 +638,7 @@ Sources:
     query: |
       SELECT * FROM parse_evtx(filename=[
          ROOT + "/Microsoft-Windows-Sysmon%4Operational.evtx",
-         ROOT + "/System.evtx"
+         ROOT + "/Security.evtx"
       ])
       WHERE System.EventID.Value = 1 OR System.EventID.Value = 4688
 


### PR DESCRIPTION
Fixed a typo with process creation checking the system evtx, rather than security.evtx for 4688 events. 