### PR TITLE
fix windows hayabusa event monitoring

### DIFF
--- a/config/windows_hayabusa_event_monitoring.yaml
+++ b/config/windows_hayabusa_event_monitoring.yaml
@@ -86,7 +86,6 @@ QueryTemplate: |
       FROM Artifact.Windows.Sigma.BaseEvents(
          ROOT=ROOT, RuleLevel=RuleLevel, RuleStatus=RuleStatus,
          RuleTitleFilter=RuleTitleFilter, RuleExclusions=RuleExclusions,
-         DateAfter=DateAfter, DateBefore=DateBefore,
          SigmaRules=Rules, NTFS_CACHE_TIME=NTFS_CACHE_TIME)
 
 # Many rules are broken and have bad field mappings. The following


### PR DESCRIPTION
### Problem Description  
Currently, `Windows.Hayabusa.Monitoring` is broken, as evident from the following log output:  

![Log Screenshot](https://github.com/user-attachments/assets/e8e1248d-59bf-49f2-b60f-e3c1f8390ac6)  

The logs indicate that the `Windows.Sigma.BaseEvents` object does not support the `DateAfter` or `DateBefore` parameters.  

---

### Proposed Solution  
This pull request removes the unsupported `DateAfter` and `DateBefore` parameters from `Windows.Hayabusa.Monitoring` to resolve the issue.  

---
