### PR TITLE
Updated Linux EBPF model to fall back to event process info

### DIFF
--- a/config/linux_ebpf_base.yaml
+++ b/config/linux_ebpf_base.yaml
@@ -112,12 +112,30 @@ ExportTemplate: |
     LET RuleFilterLambda = '''x=>x.Level =~ RuleLevelRegex AND x.Status =~ RuleStatusRegex AND x.Title =~ RuleTitleFilter AND NOT x.Title =~ ExcludeRegex'''
 
     LET GetProcInfo(PID) = to_dict(item={
-      SELECT * FROM items(item=process_tracker_get(id=System.ProcessID).Data)
+      SELECT * FROM items(item=process_tracker_get(id=PID).Data)
          WHERE _key =~ "Name|CommandLine|CreateTime|Exe|Cwd|Username"
-      }) + dict(CreateTime=timestamp(epoch=process_tracker_get(id=System.ProcessID).Data.StartTime))
+      })
+
+    // Get proc info from the process tracker but if that fails fill
+    // it from the event. The process tracker may fail to find the process
+    // if the EBPF process tracker is not enabled
+    LET GetProcInfoFallback(ProcInfo, EventData, System) = if(
+       condition=ProcInfo.Name,
+         then=ProcInfo,
+         else=dict(Name=System.ProcessName,
+                   CommandLine=join(array=EventData.argv, sep=" "),
+                   CreateTime=timestamp(epoch=EventData.ctime) || System.ThreadStartTime,
+                   Exe=EventData.pathname,
+                   Username=System.UserID))
 
     LET EBFFEvent = generate(name="EBPF Event Generator", query={
-      SELECT *, EventData + dict(ProcInfo=GetProcInfo(PID=System.ProcessID)) AS EventData
+      SELECT *, EventData + dict(
+           Test=process_tracker_get(id=System.ProcessID),
+           ProcInfo=GetProcInfoFallback(
+              ProcInfo=GetProcInfo(PID=System.ProcessID),
+              EventData=EventData,
+              System=System)
+        ) AS EventData
       FROM delay(
         query={
           SELECT timestamp(epoch=now()) AS Timestamp,

--- a/config/linux_ebpf_base_test.yaml
+++ b/config/linux_ebpf_base_test.yaml
@@ -34,16 +34,7 @@ Preamble: |
 
 QueryTemplate: |
    sources:
-   - name: MatchingSources
-     query: |
-       SELECT _key AS SourceName
-       FROM items(item=LogSources)
-       WHERE SourceName =~ LogSourceFilter
-         AND if(condition=SelectedLogSources,
-                then=SourceName in SelectedLogSources, else=TRUE)
-
-   - name: Data
-     query: |
+   - query: |
        LET X = SELECT * FROM foreach(row={
          SELECT _key AS SourceName, _value AS Query
          FROM items(item=LogSources)
@@ -51,7 +42,12 @@ QueryTemplate: |
            AND if(condition=SelectedLogSources,
                   then=SourceName in SelectedLogSources, else=TRUE)
        }, query={
-         SELECT * FROM query(query=Query, inherit=TRUE)
+         SELECT * FROM foreach(row={
+           SELECT * FROM items(item={
+             SELECT * FROM query(query=Query, inherit=TRUE)
+           })
+           WHERE _value =~ EventRegex
+         }, column="_value")
        }, async=TRUE)
 
        SELECT *

--- a/config/linux_ebpf_monitoring.yaml
+++ b/config/linux_ebpf_monitoring.yaml
@@ -17,7 +17,7 @@ Preamble: |
 
     This artifact was built on {{ .Time }}
 
-  type: CLIENT
+  type: CLIENT_EVENT
 
   parameters:
     - name: RuleLevel
@@ -76,5 +76,7 @@ DocTemplate: |
 
   You can download the artifact pack here
   [Linux-Sigma-EBPF.zip](/artifacts/Linux-Sigma-EBPF.zip)
+  and customize using instructions at
+  [Customizing Artifacts](https://sigma.velocidex.com/docs/sigma_in_velociraptor/customize/)
 
   {{ "{{< ruleset \"index.json\" >}}" }}

--- a/config/windows_etw_base.yaml
+++ b/config/windows_etw_base.yaml
@@ -131,6 +131,11 @@ ExportTemplate: |
     LET GUIDLookup(GUID) = SELECT Data.value AS Provider
       FROM stat(accessor="registry", filename=PublisherGlob + ("/" + GUID + "/@"))
 
+    LET GetProcInfo(PID) = to_dict(item={
+      SELECT * FROM items(item=process_tracker_get(id=PID).Data)
+         WHERE _key =~ "Name|CommandLine|CreateTime|Exe|Cwd|Username"
+      })
+
     {{ if .LogSources }}
     LET LogSources <= sigma_log_sources(
     {{ range .LogSources }}
@@ -169,7 +174,7 @@ DefaultDetails:
   Query: |
     x=>get(item=DefaultDetails,
            member=format(format="%v/%v",
-              args=[x.System.Provider.Name, x.System.EventID.Value])
+              args=[x.System.Provider.Name, x.System.ID])
           ) || x.Message || x.UserData || x.EventData
   Lookup:
 
@@ -239,8 +244,9 @@ Sources:
                       EventType=System.KernelEventType,
                       EventID=dict(Value=System.ID)) AS System,
                  System.KernelEventType AS EventType,
-                 EventData + dict(ProcInfo=process_tracker_get(
-                     id=System.ProcessID).Data) AS EventData
+                 EventData + dict(
+                    ProcInfo=GetProcInfo(PID=System.ProcessID)
+                 ) AS EventData
           FROM watch_etw(guid='{9E814AAD-3204-11D2-9A82-006008A86939}',
                          capture_state=TRUE,
                          level=5,
@@ -276,8 +282,9 @@ Sources:
                   EventType=get(item=WindowsKernelFile_EIDLookup,
                                 field=str(str=System.ID)),
                   EventID=dict(Value=System.ID)) AS System,
-             EventData + dict(ProcInfo=process_tracker_get(
-                 id=System.ProcessID).Data) AS EventData
+             EventData + dict(
+                 ProcInfo=GetProcInfo(PID=System.ProcessID)
+             ) AS EventData
       FROM delay(query={
          SELECT * FROM watch_etw(
             guid='{edd08927-9cc4-4e65-b970-c2560fb5c289}',
@@ -316,10 +323,8 @@ Sources:
                                 field=str(str=System.ID)),
                   EventID=dict(Value=System.ID)) AS System,
              EventData + dict(
-                 ProcInfo=process_tracker_get(
-                   id=EventData.ProcessID).Data,
-                 ParentProcInfo=process_tracker_get(
-                   id=System.ProcessID).Data) AS EventData
+                 ProcInfo=GetProcInfo(PID=System.ProcessID)
+             ) AS EventData
       FROM delay(query={
          SELECT * FROM watch_etw(
             guid='{70eb4f03-c1de-4f73-a051-33d13d5413bd}',
@@ -347,10 +352,8 @@ Sources:
                                 field=str(str=System.ID)),
                   EventID=dict(Value=System.ID)) AS System,
              EventData + dict(
-                 ProcInfo=process_tracker_get(
-                   id=EventData.ProcessID).Data,
-                 ParentProcInfo=process_tracker_get(
-                   id=System.ProcessID).Data) AS EventData
+                ProcInfo=GetProcInfo(PID=System.ProcessID)
+             ) AS EventData
       FROM delay(query={
          SELECT * FROM watch_etw(
             guid='{22fb2cd6-0e7b-422b-a0c7-2fad1fd0e716}',

--- a/config/windows_etw_base_test.yaml
+++ b/config/windows_etw_base_test.yaml
@@ -9,7 +9,7 @@ Preamble: |
     Windows.Sigma.ETWBase. It is used to acquire a dataset for the
     `SigmaStudio` notebook.
 
-  type: CLIENT
+  type: CLIENT_EVENT
   parameters:
     - name: LogSourceFilter
       description: Only capture log sources that match this regex.
@@ -43,7 +43,12 @@ QueryTemplate: |
            AND if(condition=SelectedLogSources,
                   then=SourceName in SelectedLogSources, else=TRUE)
        }, query={
-         SELECT * FROM query(query=Query, inherit=TRUE)
+         SELECT * FROM foreach(row={
+           SELECT * FROM items(item={
+             SELECT * FROM query(query=Query, inherit=TRUE)
+           })
+           WHERE _value =~ EventRegex
+         }, column="_value")
        }, async=TRUE)
 
        SELECT *


### PR DESCRIPTION
if the process tracker is not initialized then it may not be able to find the relevant process (if it is very short lived) but in this case some of the information is already delivered in the event itself. Copying it into the ProcInfo field will allow rules to match against these.