### PR TITLE
Added process_creation log source and macOS Sigma Triage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ windows:
 
 compile: compileThirdParty
 
-compileThirdParty:  compileHayabusa compileHayabusaMonitoring compileLinuxTriage compileWindowsETW compileHayabusaMonitoring compileLinuxEBPF compileWindowsVQL
+compileThirdParty:  compileHayabusa compileHayabusaMonitoring compileLinuxTriage compileWindowsETW compileHayabusaMonitoring compileLinuxEBPF compileWindowsVQL compileMacOSBaseVQL
 
 compileWindowsBaseDebug:
 	dlv debug ./src/ -- compile --config ./config/windows_base.yaml --output ./output/Windows-Sigma-Base.zip --yaml ./output/Windows.Sigma.Base.yaml --docs ./docs/content/docs/models/windows_base/_index.md
@@ -49,6 +49,11 @@ compileLinuxEBPFBase:
 
 compileWindowsETW: compileWindowsBaseETW
 	./velosigmac compile --config ./config/windows_etw_monitoring.yaml --output ./output/Windows-ETW-Monitoring.zip --yaml ./output/Windows.ETW.Monitoring.yaml --rule_dir ./docs/content/docs/artifacts/Windows.ETW.Monitoring/ --docs ./docs/content/docs/artifacts/Windows.ETW.Monitoring/_index.md
+
+compileMacOSBaseVQL:
+	./velosigmac compile --config ./config/macos_base_vql.yaml --output ./output/MacOS-Sigma-BaseVQL.zip --yaml ./output/MacOS.Sigma.BaseVQL.yaml --docs ./docs/content/docs/models/macos_base_vql/_index.md
+	./velosigmac compile --config ./config/macos_base_vql_test.yaml --yaml ./output/MacOS.Sigma.BaseVQL.CaptureTestSet.yaml
+	./velosigmac compile --config ./config/macos_base_vql_test_replay.yaml --yaml ./output/MacOS.Sigma.BaseVQL.ReplayTestSet.yaml
 
 compileWindowsBaseVQL:
 	./velosigmac compile --config ./config/windows_base_vql.yaml --output ./output/Windows-Sigma-BaseVQL.zip --yaml ./output/Windows.Sigma.BaseVQL.yaml  --docs ./docs/content/docs/models/windows_base_vql/_index.md

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ windows:
 
 compile: compileThirdParty
 
-compileThirdParty:  compileHayabusa compileHayabusaMonitoring compileLinuxTriage compileWindowsETW compileHayabusaMonitoring compileLinuxEBPF compileWindowsVQL compileMacOSBaseVQL
+compileThirdParty:  compileHayabusa compileHayabusaMonitoring compileLinuxTriage compileWindowsETW compileHayabusaMonitoring compileLinuxEBPF compileWindowsVQL compileMacOSBaseVQL compileMacOSTriage
 
 compileWindowsBaseDebug:
 	dlv debug ./src/ -- compile --config ./config/windows_base.yaml --output ./output/Windows-Sigma-Base.zip --yaml ./output/Windows.Sigma.Base.yaml --docs ./docs/content/docs/models/windows_base/_index.md
@@ -54,6 +54,9 @@ compileMacOSBaseVQL:
 	./velosigmac compile --config ./config/macos_base_vql.yaml --output ./output/MacOS-Sigma-BaseVQL.zip --yaml ./output/MacOS.Sigma.BaseVQL.yaml --docs ./docs/content/docs/models/macos_base_vql/_index.md
 	./velosigmac compile --config ./config/macos_base_vql_test.yaml --yaml ./output/MacOS.Sigma.BaseVQL.CaptureTestSet.yaml
 	./velosigmac compile --config ./config/macos_base_vql_test_replay.yaml --yaml ./output/MacOS.Sigma.BaseVQL.ReplayTestSet.yaml
+
+compileMacOSTriage: compileMacOSBaseVQL
+	./velosigmac compile --config ./config/macos_sigma_triage.yaml --output ./output/MacOS-Sigma-Triage.zip --yaml ./output/MacOS.Sigma.Triage.yaml --rule_dir ./docs/content/docs/artifacts/MacOS.Sigma.Triage/ --docs ./docs/content/docs/artifacts/MacOS.Sigma.Triage/_index.md
 
 compileWindowsBaseVQL:
 	./velosigmac compile --config ./config/windows_base_vql.yaml --output ./output/Windows-Sigma-BaseVQL.zip --yaml ./output/Windows.Sigma.BaseVQL.yaml  --docs ./docs/content/docs/models/windows_base_vql/_index.md

--- a/config/macos_base_vql.yaml
+++ b/config/macos_base_vql.yaml
@@ -1,0 +1,260 @@
+Name: MacOS.Sigma.BaseVQL
+ImportConfigs:
+  - config/base_doc.yaml
+
+Description: |
+  # macOS Base VQL Sigma Model
+
+  This model is designed for triage of macOS systems using VQL-based
+  Sigma rules. The rules that use this model will be evaluated once
+  on all events.
+
+  After all relevant rules are evaluated, the collection is complete.
+
+  Rules that utilise this model may include a `vql` section which may
+  contain a VQL lambda to dictate how the event is generated. This
+  allows the rule itself to generate all relevant fields.
+
+  For example:
+
+  ```yaml
+  vql: |
+  x=>dict(
+    Timestamp=timestamp(epoch=now()),
+    EventData=dict(
+      FieldA="value",
+      FieldB=SomeVQLExpression
+    ))
+  ```
+
+Preamble: |
+  name: MacOS.Sigma.BaseVQL
+  description: |
+    This artifact builds the basic set of log sources and field
+    mappings used for Sigma Forensic Triage on macOS.
+
+    NOTE: This artifact does not include any rules. You can launch it
+    with rules provided to the SigmaRules parameter or call it from
+    another artifact with a set of rules passed to the SigmaRules
+    parameter.
+
+    This artifact was built on {{ .Time }}
+
+  type: CLIENT
+
+  precondition:
+    SELECT OS FROM info() WHERE OS = 'darwin'
+
+  parameters:
+    - name: Debug
+      type: bool
+      description: Enable full debug trace
+
+    - name: RuleLevel
+      type: choices
+      default: All
+      choices:
+        - "Critical"
+        - "Critical and High"
+        - "Critical, High, and Medium"
+        - "All"
+
+    - name: RuleStatus
+      type: choices
+      default: All Rules
+      choices:
+        - Stable
+        - Stable and Experimental
+        - Stable and Test
+        - All Rules
+
+    - name: RuleTitleFilter
+      type: regex
+      default: .
+      description: Use this to filter only some rules to match
+
+    - name: RuleExclusions
+      type: csv
+      description: |
+        This table are rules that will be excluded by Title Regex
+      default: |
+        RuleTitleRegex,Reason
+        noisy,All rules marked noisy should be disabled by default.
+
+    - name: DateAfter
+      description: "search for events after this date. YYYY-MM-DDTmm:hh:ss Z"
+      type: timestamp
+
+    - name: DateBefore
+      description: "search for events before this date. YYYY-MM-DDTmm:hh:ss Z"
+      type: timestamp
+
+    - name: SigmaRules
+      description: If provided we use these rules instead of the built in set.
+
+ExportTemplate: |
+  export: |
+    LET X = scope()
+
+    LET DateAfterTime <= X.DateAfter || timestamp(epoch="1600-01-01")
+    LET DateBeforeTime <= X.DateBefore || timestamp(epoch="2200-01-01")
+
+    LET ExcludeRegex <= if(condition=X.RuleExclusions,
+         then=join(array=RuleExclusions.RuleTitleRegex, sep="|"),
+         else="XXXXXXX")
+
+    LET RuleStatusRegex <= get(item=dict(
+         `Stable`="stable",
+         `Stable and Experimental`="stable|experimental",
+         `Stable and Test`="stable|test",
+         `All Rules`="."), member=X.RuleStatus || "All Rules")
+
+    LET RuleLevelRegex <= get(item=dict(
+         `Critical`="critical",
+         `Critical and High`="critical|high",
+         `Critical, High, and Medium`="critical|high|medium|default",
+         `All`="."), member=X.RuleLevel || "All")
+
+    LET Hostname <= dict(H={ SELECT Hostname FROM info()}).H[0].Hostname
+
+    {{ if .LogSources }}
+    LET LogSources <= sigma_log_sources(
+    {{ range .LogSources }}
+      `{{ .Name }}`={
+  {{ Indent .Query 5 }}
+      },
+    {{- end -}}
+    `velociraptor/info/*`={ SELECT * FROM info() })
+    {{ end }}
+
+    LET FieldMapping <= parse_json(data=gunzip(string=base64decode(string="{{.Base64FieldMapping}}")))
+
+    LET DefaultDetails <= parse_json(data=gunzip(string=base64decode(string="{{.Base64DefaultDetailsLookup}}")))
+
+    LET DefaultDetailsLambda = '''{{.Base64DefaultDetailsQuery}}'''
+    LET RuleFilterLambda = '''x=>x.Level =~ RuleLevelRegex AND x.Status =~ RuleStatusRegex AND x.Title =~ RuleTitleFilter AND NOT x.Title =~ ExcludeRegex'''
+
+
+FieldMappings:
+  EventData: "x=>x.EventData"
+  Timestamp: "x=>x.Timestamp"
+  Service: "x=>x.EventData.Service"
+  Client: "x=>x.EventData.Client"
+  ClientType: "x=>x.EventData.ClientType"
+  AuthValue: "x=>x.EventData.AuthValue"
+  AuthReason: "x=>x.EventData.AuthReason"
+  User: "x=>x.EventData.User"
+  LastModified: "x=>x.EventData.LastModified"
+  IndirectObjectIdentifier: "x=>x.EventData.IndirectObjectIdentifier"
+  Flags: "x=>x.EventData.Flags"
+
+
+DefaultDetails:
+  Query: |
+    x=>x.EventData
+  Lookup:
+    X: X
+
+Sources:
+  vql/macos/*:
+    description: |
+      This log source emits a single event. All rules using the log
+      source will receive this event, where they can run arbitrary VQL
+      queries to build the event themselves.
+
+      This is most useful for rules that want to generate their own
+      event data.
+
+    query: |
+      SELECT timestamp(epoch=now()) AS Timestamp,
+        dict(
+          Computer=Hostname,
+          Channel="VQL Evaluation",
+          TimeCreated=dict(SystemTime=now())
+        ) AS System,
+        dict() AS EventData
+      FROM scope()
+    fields:
+      - Timestamp
+      - EventData
+      - System
+
+  '*/macos/tcc':
+    description: |
+      Queries the TCC (Transparency, Consent, and Control) database
+      for privacy permission grants. Returns one row per permission
+      entry from both system-wide and per-user TCC databases.
+
+      The Velociraptor client service (LaunchDaemon) must be granted
+      Full Disk Access to read the system-wide TCC.db.
+
+    samples:
+      - name: "TCC access entry"
+        json: "config/samples/MacOS-TCC-access.json"
+
+    query: |
+      SELECT timestamp(epoch=last_modified) AS Timestamp,
+        dict(
+          Computer=Hostname,
+          Channel="TCC.db"
+        ) AS System,
+        dict(
+          Service=service,
+          Client=client,
+          ClientType=client_type,
+          AuthValue=auth_value,
+          AuthReason=auth_reason,
+          User=if(condition=OSPath =~ "Users",
+                  then=path_split(path=OSPath)[-5],
+                  else="System"),
+          LastModified=timestamp(epoch=last_modified),
+          IndirectObjectIdentifier=indirect_object_identifier,
+          Flags=flags
+        ) AS EventData
+      FROM foreach(row={
+        SELECT OSPath
+        FROM glob(globs=split(string="/Library/Application Support/com.apple.TCC/TCC.db,/Users/*/Library/Application Support/com.apple.TCC/TCC.db", sep=","))
+      }, query={
+        SELECT *, OSPath
+        FROM sqlite(file=OSPath, query="SELECT * FROM access")
+      })
+    fields:
+      - Service
+      - Client
+      - ClientType
+      - AuthValue
+      - AuthReason
+      - User
+      - LastModified
+      - IndirectObjectIdentifier
+      - Flags
+
+QueryTemplate: |
+ sources:
+ - query: |
+    LET Result = SELECT Timestamp,
+          System.Computer AS Computer,
+          System.Channel AS Channel,
+          _Rule.Level AS Level,
+          _Rule.Title AS Title,
+          Details,
+          dict(System=System,
+               EventData=X.EventData || X.UserData,
+               Message=X.Message) AS _Event,
+          _Match, *
+    FROM sigma(
+      rules=split(string=SigmaRules, sep="\n---+\r?\n"),
+      log_sources= LogSources, debug=Debug,
+      default_details=DefaultDetailsLambda,
+      rule_filter=RuleFilterLambda,
+      field_mapping= FieldMapping)
+
+    SELECT * FROM if(condition=Debug, then={
+      SELECT * FROM Result
+    }, else={
+      SELECT Timestamp, Computer, Channel,
+             Level, Title, Details,
+             _Event,
+             X.Enrichment AS Enrichment
+      FROM Result
+    })

--- a/config/macos_base_vql.yaml
+++ b/config/macos_base_vql.yaml
@@ -117,6 +117,16 @@ ExportTemplate: |
 
     LET Hostname <= dict(H={ SELECT Hostname FROM info()}).H[0].Hostname
 
+    LET _AllProcs <= SELECT Pid, Ppid, Name, Exe,
+          CommandLine, Username, CreateTime
+    FROM pslist()
+
+    LET _ProcLookup <= to_dict(item={
+      SELECT str(str=Pid) AS _key,
+             dict(Exe=Exe, CommandLine=CommandLine) AS _value
+      FROM _AllProcs
+    })
+
     {{ if .LogSources }}
     LET LogSources <= sigma_log_sources(
     {{ range .LogSources }}
@@ -147,6 +157,10 @@ FieldMappings:
   LastModified: "x=>x.EventData.LastModified"
   IndirectObjectIdentifier: "x=>x.EventData.IndirectObjectIdentifier"
   Flags: "x=>x.EventData.Flags"
+  Image: "x=>x.EventData.Image"
+  CommandLine: "x=>x.EventData.CommandLine"
+  ParentImage: "x=>x.EventData.ParentImage"
+  ParentCommandLine: "x=>x.EventData.ParentCommandLine"
 
 
 DefaultDetails:
@@ -228,6 +242,49 @@ Sources:
       - LastModified
       - IndirectObjectIdentifier
       - Flags
+
+  process_creation/macos/*:
+    description: |
+      Lists all running processes using pslist() and looks up each parent
+      process by Ppid. Returns one row per process.
+
+      This captures a snapshot at the time of collection, not a continuous
+      stream. Processes that start and stop quickly may not appear in the
+      results.
+
+      Unlike Windows (Event Logs) or Linux (auditd), macOS does not keep a
+      history of process creation. The Unified Log does not include command-line
+      arguments for executed processes.
+
+      Future work: 
+      - ESF-based real-time monitoring for event-stream coverage
+        similar to Windows ETW and Linux eBPF.
+      - Shell history (~/.zsh_history, ~/.bash_history) as a
+        complementary log source for historical interactive commands. Covers
+        typed commands with timestamps but not non-interactive processes
+        (LaunchDaemons, cron, GUI apps).
+
+    query: |
+      SELECT CreateTime AS Timestamp,
+             dict(Computer=Hostname, Channel='Velociraptor') AS System,
+             dict(
+               CreateTime=CreateTime,
+               CommandLine=CommandLine,
+               Image=Exe,
+               Pid=Pid,
+               ParentCommandLine=get(item=_ProcLookup,
+                   member=str(str=Ppid)).CommandLine,
+               ParentImage=get(item=_ProcLookup,
+                   member=str(str=Ppid)).Exe,
+               User=Username
+             ) AS EventData
+      FROM _AllProcs
+    fields:
+      - CommandLine
+      - Image
+      - ParentCommandLine
+      - ParentImage
+      - User
 
 QueryTemplate: |
  sources:

--- a/config/macos_base_vql_test.yaml
+++ b/config/macos_base_vql_test.yaml
@@ -1,0 +1,95 @@
+Name: MacOS.Sigma.BaseVQL.CaptureTestSet
+ImportConfigs:
+  - config/macos_base_vql.yaml
+
+Preamble: |
+  name: MacOS.Sigma.BaseVQL.CaptureTestSet
+  description: |
+    This artifact captures a test set of the log sources defined by
+    MacOS.Sigma.BaseVQL. It is used to acquire a dataset for the
+    `SigmaStudio` notebook.
+
+  type: CLIENT
+
+  # Uses the query() plugin
+  implied_permissions:
+    - IMPERSONATION
+
+  parameters:
+    - name: Debug
+      type: bool
+      description: Enable full debug trace
+    - name: RuleLevel
+      type: choices
+      default: All
+      choices:
+        - Critical
+        - Critical and High
+        - All
+
+    - name: RuleStatus
+      type: choices
+      default: All Rules
+      choices:
+        - Stable
+        - Stable and Experimental
+        - Stable and Test
+        - All Rules
+
+    - name: RuleExclusions
+      type: csv
+      description: |
+        This table are rules that will be excluded by Title Regex
+      default: |
+        RuleTitleRegex,Reason
+        noisy,All rules marked noisy should be disabled by default.
+
+    - name: RuleTitleFilter
+      type: regex
+      default: .
+      description: Use this to filter only some rules to match
+
+    - name: LogSourceFilter
+      description: Only capture log sources that match this regex.
+      type: regex
+      default: .
+
+    - name: SelectedLogSources
+      description: Set to capture only those log sources.
+      type: multichoice
+      choices:
+      {{- range .ImportedLogSources }}
+      - "{{ .Name }}"
+      {{- end }}
+
+    - name: EventRegex
+      description: Only capture events that match this regex (the event is converted to JSON first).
+      type: regex
+      default: .
+
+  imports:
+    - MacOS.Sigma.BaseVQL
+
+QueryTemplate: |
+   sources:
+   - name: MatchingSources
+     query: |
+       SELECT _key AS SourceName
+       FROM items(item=LogSources)
+       WHERE SourceName =~ LogSourceFilter
+         AND if(condition=SelectedLogSources, then=SourceName in SelectedLogSources, else=TRUE)
+
+   - query: |
+       SELECT * FROM foreach(row={
+         SELECT _key AS SourceName, _value AS Query
+         FROM items(item=LogSources)
+         WHERE SourceName =~ LogSourceFilter
+           AND if(condition=SelectedLogSources, then=SourceName in SelectedLogSources, else=TRUE)
+       }, query={
+         SELECT * FROM foreach(row={
+           SELECT * FROM items(item={
+             SELECT * FROM query(query=Query, inherit=TRUE)
+           })
+           WHERE _value =~ EventRegex
+         }, column="_value")
+       })

--- a/config/macos_base_vql_test_replay.yaml
+++ b/config/macos_base_vql_test_replay.yaml
@@ -1,0 +1,52 @@
+Name: MacOS.Sigma.BaseVQL.ReplayTestSet
+ImportConfigs:
+  - config/macos_base_vql.yaml
+
+Preamble: |
+  name: MacOS.Sigma.BaseVQL.ReplayTestSet
+  description: |
+    This artifact replays a previously captured test set into the rules.
+
+  type: CLIENT
+  parameters:
+   - name: JSONDump
+     description: A path to the JSON dump of the test set
+     default: /path/to/file.json
+
+   - name: Debug
+     description: Enable this to match all rules (even if they did not match) in order to see what detections matched.
+     type: bool
+
+   - name: SigmaRules
+     description: Sigma Rules to test
+
+  imports:
+    - MacOS.Sigma.BaseVQL
+
+QueryTemplate: |
+   sources:
+   - query: |
+       // Feed all the json rows to the log sources.
+       LET AllRows = SELECT * FROM parse_jsonl(filename=JSONDump)
+
+       LET TestingLogSourceDict <= to_dict(item={
+         SELECT _key, AllRows AS _value
+         FROM items(item=LogSources)
+       })
+
+       // Build the log sources automatically.
+       LET TestingLogSources <= sigma_log_sources(`**`=TestingLogSourceDict)
+
+       // Apply the Sigma Rules on the samples.
+       SELECT  _Rule.Title AS Rule ,
+         Details,
+         dict(System=System,
+              EventData=X.EventData || X.UserData,
+              Message=X.Message) AS Event,
+         _Match AS Match
+
+       FROM sigma(
+          rules=split(string=SigmaRules, sep="\n---+\r?\n"),
+          log_sources= TestingLogSources, debug=Debug,
+          default_details=DefaultDetailsLambda,
+          field_mapping= FieldMapping)

--- a/config/macos_sigma_triage.yaml
+++ b/config/macos_sigma_triage.yaml
@@ -1,0 +1,103 @@
+Name: MacOS.Sigma.Triage
+ImportConfigs:
+  - config/macos_base_vql.yaml
+
+IncludeArtifacts:
+  - output/MacOS.Sigma.BaseVQL.yaml
+
+Preamble: |
+  name: MacOS.Sigma.Triage
+  description: |
+    This artifact compiles the macOS rules from SigmaHQ into a Velociraptor
+    artifact using the macOS Sigma Base model.
+
+    Currently covers process_creation rules only.
+
+    This artifact was built on {{ .Time }}
+
+  type: CLIENT
+
+  parameters:
+    - name: Debug
+      type: bool
+      description: Enable full debug trace
+
+    - name: RuleLevel
+      type: choices
+      default: All
+      choices:
+        - "Critical"
+        - "Critical and High"
+        - "Critical, High, and Medium"
+        - "All"
+
+    - name: RuleStatus
+      type: choices
+      default: All Rules
+      choices:
+        - Stable
+        - Stable and Experimental
+        - Stable and Test
+        - All Rules
+
+    - name: RuleTitleFilter
+      type: regex
+      default: .
+      description: Use this to filter only some rules to match
+
+    - name: RuleExclusions
+      type: csv
+      description: |
+        This table are rules that will be excluded by Title Regex
+      default: |
+        RuleTitleRegex,Reason
+        noisy,All rules marked noisy should be disabled by default.
+
+    - name: DateAfter
+      description: "search for events after this date. YYYY-MM-DDTmm:hh:ss Z"
+      type: timestamp
+
+    - name: DateBefore
+      description: "search for events before this date. YYYY-MM-DDTmm:hh:ss Z"
+      type: timestamp
+
+  imports:
+    - MacOS.Sigma.BaseVQL
+
+QueryTemplate: |
+   sources:
+   - query: |
+       LET Rules <= gunzip(string=base64decode(string="{{.Base64CompressedRules}}"))
+       SELECT *
+       FROM Artifact.MacOS.Sigma.BaseVQL(
+          RuleLevel=RuleLevel, RuleStatus=RuleStatus,
+          RuleTitleFilter=RuleTitleFilter, Debug=Debug,
+          RuleExclusions=RuleExclusions,
+          DateAfter=DateAfter, DateBefore=DateBefore,
+          SigmaRules=Rules)
+
+RuleDirectories:
+  - rules/sigma/rules/macos/process_creation/
+
+DocTemplate: |
+  ---
+  title: MacOS.Sigma.Triage
+  weight: 20
+  bookToc: false
+  IconClass: fa-solid fa-book
+  ---
+
+  # MacOS.Sigma.Triage artifact
+
+  This artifact compiles the macOS rules from SigmaHQ into a Velociraptor
+  artifact using the macOS Sigma Base model. Currently covers process_creation
+  rules only.
+
+  Base Artifact: [MacOS.Sigma.BaseVQL](/docs/models/macos_base_vql/)
+
+  You can download the artifact pack here
+  [MacOS-Sigma-Triage.zip](/artifacts/MacOS-Sigma-Triage.zip)
+  and customize using instructions at
+  [Customizing Artifacts](https://sigma.velocidex.com/docs/sigma_in_velociraptor/customize/)
+
+  {{ "{{< ruleset \"index.json\" >}}" }}

--- a/config/samples/MacOS-TCC-access.json
+++ b/config/samples/MacOS-TCC-access.json
@@ -1,0 +1,1 @@
+{"Timestamp":"2025-01-15T10:30:00Z","System":{"Computer":"mac-host.local","Channel":"TCC.db"},"EventData":{"Service":"kTCCServiceSystemPolicyAllFiles","Client":"/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal","ClientType":0,"AuthValue":2,"AuthReason":4,"User":"System","LastModified":"2025-01-15T10:30:00Z","IndirectObjectIdentifier":"UNUSED","Flags":0}}

--- a/tests/testcases/fixtures/macos_pslist_process.json
+++ b/tests/testcases/fixtures/macos_pslist_process.json
@@ -1,0 +1,2 @@
+[{"Pid": 1234, "Ppid": 567, "Name": "base64", "Exe": "/usr/bin/base64", "CommandLine": "/usr/bin/base64 -d /tmp/payload.enc", "Username": "admin", "CreateTime": "2025-06-15T09:00:00Z"},
+{"Pid": 567, "Ppid": 1, "Name": "bash", "Exe": "/bin/bash", "CommandLine": "/bin/bash -c /usr/bin/base64 -d /tmp/payload.enc", "Username": "admin", "CreateTime": "2025-06-15T08:55:00Z"}]

--- a/tests/testcases/fixtures/macos_tcc_access.json
+++ b/tests/testcases/fixtures/macos_tcc_access.json
@@ -1,0 +1,10 @@
+{
+    "service": "kTCCServiceSystemPolicyAllFiles",
+    "client": "/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal",
+    "client_type": 0,
+    "auth_value": 2,
+    "auth_reason": 4,
+    "indirect_object_identifier": "UNUSED",
+    "flags": 0,
+    "last_modified": 1736937000
+}

--- a/tests/testcases/macos_pslist.in.yaml
+++ b/tests/testcases/macos_pslist.in.yaml
@@ -1,0 +1,21 @@
+Parameters:
+  PslistRows: /testcases/fixtures/macos_pslist_process.json
+  SigmaRule: |
+    title: Base64 Decode Detected
+    status: test
+    logsource:
+      category: process_creation
+      product: macos
+    detection:
+      selection:
+        Image|endswith: '/base64'
+        CommandLine|contains: '-d'
+      condition: selection
+    level: critical
+
+Queries:
+- LET _ <= SELECT mock(plugin='info', results=[dict(Hostname="test-mac.local", OS="darwin"),]) FROM scope()
+
+- LET _ <= SELECT mock(plugin='pslist', results=parse_json_array(data=read_file(filename=testDir + PslistRows))) FROM scope()
+
+- SELECT * FROM Artifact.MacOS.Sigma.BaseVQL(SigmaRules=SigmaRule, RuleLevel='All', RuleStatus='All Rules') LIMIT 1

--- a/tests/testcases/macos_pslist.out.yaml
+++ b/tests/testcases/macos_pslist.out.yaml
@@ -1,0 +1,44 @@
+Query: LET _ <= SELECT mock(plugin='info', results=[dict(Hostname="test-mac.local", OS="darwin"),]) FROM scope()
+Output: []
+
+Query: LET _ <= SELECT mock(plugin='pslist', results=parse_json_array(data=read_file(filename=testDir + PslistRows))) FROM scope()
+Output: []
+
+Query: SELECT * FROM Artifact.MacOS.Sigma.BaseVQL(SigmaRules=SigmaRule, RuleLevel='All', RuleStatus='All Rules') LIMIT 1
+Output: [
+ {
+  "Timestamp": "2025-06-15T09:00:00Z",
+  "Computer": "test-mac.local",
+  "Channel": "Velociraptor",
+  "Level": "critical",
+  "Title": "Base64 Decode Detected",
+  "Details": {
+   "CreateTime": "2025-06-15T09:00:00Z",
+   "CommandLine": "/usr/bin/base64 -d /tmp/payload.enc",
+   "Image": "/usr/bin/base64",
+   "Pid": 1234,
+   "ParentCommandLine": "/bin/bash -c /usr/bin/base64 -d /tmp/payload.enc",
+   "ParentImage": "/bin/bash",
+   "User": "admin"
+  },
+  "_Event": {
+   "System": {
+    "Computer": "test-mac.local",
+    "Channel": "Velociraptor"
+   },
+   "EventData": {
+    "CreateTime": "2025-06-15T09:00:00Z",
+    "CommandLine": "/usr/bin/base64 -d /tmp/payload.enc",
+    "Image": "/usr/bin/base64",
+    "Pid": 1234,
+    "ParentCommandLine": "/bin/bash -c /usr/bin/base64 -d /tmp/payload.enc",
+    "ParentImage": "/bin/bash",
+    "User": "admin"
+   },
+   "Message": null
+  },
+  "Enrichment": null,
+  "_Source": "MacOS.Sigma.BaseVQL"
+ }
+]
+

--- a/tests/testcases/macos_tcc.in.yaml
+++ b/tests/testcases/macos_tcc.in.yaml
@@ -1,0 +1,23 @@
+Parameters:
+  TCCRow: /testcases/fixtures/macos_tcc_access.json
+  SigmaRule: |
+    title: FDA Access Detected
+    status: test
+    logsource:
+      product: macos
+      service: tcc
+    detection:
+      selection:
+        Service: kTCCServiceSystemPolicyAllFiles
+        AuthValue: 2
+      condition: selection
+    level: critical
+
+Queries:
+- LET _ <= SELECT mock(plugin='info', results=[dict(Hostname="test-mac.local", OS="darwin"),]) FROM scope()
+
+- LET _ <= SELECT mock(plugin='glob', results=[dict(OSPath="/Library/Application Support/com.apple.TCC/TCC.db"),]) FROM scope()
+
+- LET _ <= SELECT mock(plugin='sqlite', results=[parse_json(data=read_file(filename=testDir + TCCRow)),]) FROM scope()
+
+- SELECT * FROM Artifact.MacOS.Sigma.BaseVQL(SigmaRules=SigmaRule, RuleLevel='All', RuleStatus='All Rules') LIMIT 1

--- a/tests/testcases/macos_tcc.out.yaml
+++ b/tests/testcases/macos_tcc.out.yaml
@@ -1,0 +1,51 @@
+Query: LET _ <= SELECT mock(plugin='info', results=[dict(Hostname="test-mac.local", OS="darwin"),]) FROM scope()
+Output: []
+
+Query: LET _ <= SELECT mock(plugin='glob', results=[dict(OSPath="/Library/Application Support/com.apple.TCC/TCC.db"),]) FROM scope()
+Output: []
+
+Query: LET _ <= SELECT mock(plugin='sqlite', results=[parse_json(data=read_file(filename=testDir + TCCRow)),]) FROM scope()
+Output: []
+
+Query: SELECT * FROM Artifact.MacOS.Sigma.BaseVQL(SigmaRules=SigmaRule, RuleLevel='All', RuleStatus='All Rules') LIMIT 1
+Output: [
+ {
+  "Timestamp": "2025-01-15T10:30:00Z",
+  "Computer": "test-mac.local",
+  "Channel": "TCC.db",
+  "Level": "critical",
+  "Title": "FDA Access Detected",
+  "Details": {
+   "Service": "kTCCServiceSystemPolicyAllFiles",
+   "Client": "/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal",
+   "ClientType": 0,
+   "AuthValue": 2,
+   "AuthReason": 4,
+   "User": "System",
+   "LastModified": "2025-01-15T10:30:00Z",
+   "IndirectObjectIdentifier": "UNUSED",
+   "Flags": 0
+  },
+  "_Event": {
+   "System": {
+    "Computer": "test-mac.local",
+    "Channel": "TCC.db"
+   },
+   "EventData": {
+    "Service": "kTCCServiceSystemPolicyAllFiles",
+    "Client": "/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal",
+    "ClientType": 0,
+    "AuthValue": 2,
+    "AuthReason": 4,
+    "User": "System",
+    "LastModified": "2025-01-15T10:30:00Z",
+    "IndirectObjectIdentifier": "UNUSED",
+    "Flags": 0
+   },
+   "Message": null
+  },
+  "Enrichment": null,
+  "_Source": "MacOS.Sigma.BaseVQL"
+ }
+]
+

--- a/tests/testcases/macos_triage.in.yaml
+++ b/tests/testcases/macos_triage.in.yaml
@@ -1,0 +1,9 @@
+Parameters:
+  PslistRows: /testcases/fixtures/macos_pslist_process.json
+
+Queries:
+- LET _ <= SELECT mock(plugin='info', results=[dict(Hostname="test-mac.local", OS="darwin"),]) FROM scope()
+
+- LET _ <= SELECT mock(plugin='pslist', results=parse_json_array(data=read_file(filename=testDir + PslistRows))) FROM scope()
+
+- SELECT * FROM Artifact.MacOS.Sigma.Triage(RuleLevel='All', RuleStatus='All Rules') ORDER BY Title LIMIT 1

--- a/tests/testcases/macos_triage.out.yaml
+++ b/tests/testcases/macos_triage.out.yaml
@@ -1,0 +1,44 @@
+Query: LET _ <= SELECT mock(plugin='info', results=[dict(Hostname="test-mac.local", OS="darwin"),]) FROM scope()
+Output: []
+
+Query: LET _ <= SELECT mock(plugin='pslist', results=parse_json_array(data=read_file(filename=testDir + PslistRows))) FROM scope()
+Output: []
+
+Query: SELECT * FROM Artifact.MacOS.Sigma.Triage(RuleLevel='All', RuleStatus='All Rules') ORDER BY Title LIMIT 1
+Output: [
+ {
+  "Timestamp": "2025-06-15T09:00:00Z",
+  "Computer": "test-mac.local",
+  "Channel": "Velociraptor",
+  "Level": "low",
+  "Title": "Decode Base64 Encoded Text -MacOs",
+  "Details": {
+   "CreateTime": "2025-06-15T09:00:00Z",
+   "CommandLine": "/usr/bin/base64 -d /tmp/payload.enc",
+   "Image": "/usr/bin/base64",
+   "Pid": 1234,
+   "ParentCommandLine": "/bin/bash -c /usr/bin/base64 -d /tmp/payload.enc",
+   "ParentImage": "/bin/bash",
+   "User": "admin"
+  },
+  "_Event": {
+   "System": {
+    "Computer": "test-mac.local",
+    "Channel": "Velociraptor"
+   },
+   "EventData": {
+    "CreateTime": "2025-06-15T09:00:00Z",
+    "CommandLine": "/usr/bin/base64 -d /tmp/payload.enc",
+    "Image": "/usr/bin/base64",
+    "Pid": 1234,
+    "ParentCommandLine": "/bin/bash -c /usr/bin/base64 -d /tmp/payload.enc",
+    "ParentImage": "/bin/bash",
+    "User": "admin"
+   },
+   "Message": null
+  },
+  "Enrichment": null,
+  "_Source": "MacOS.Sigma.Triage"
+ }
+]
+


### PR DESCRIPTION
- Added process_creation log source to MacOS.Sigma.BaseVQL so SigmaHQ process_creation rules can be compiled
- Added MacOS.Sigma.Triage config with SigmaHQ macos process_creation rules
- Added compileMacOSTriage Makefile target (depends on compileMacOSBaseVQL)
- Added golden tests for BaseVQL process_creation and Triage artifact