### PR TITLE
Added macOS Sigma process_creation rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ windows:
 
 compile: compileThirdParty
 
-compileThirdParty:  compileHayabusa compileHayabusaMonitoring compileLinuxTriage compileWindowsETW compileHayabusaMonitoring compileLinuxEBPF compileWindowsVQL compileMacOSBaseVQL
+compileThirdParty:  compileHayabusa compileHayabusaMonitoring compileLinuxTriage compileWindowsETW compileHayabusaMonitoring compileLinuxEBPF compileWindowsVQL compileMacOSBaseVQL compileMacOSTriage
 
 compileWindowsBaseDebug:
 	dlv debug ./src/ -- compile --config ./config/windows_base.yaml --output ./output/Windows-Sigma-Base.zip --yaml ./output/Windows.Sigma.Base.yaml --docs ./docs/content/docs/models/windows_base/_index.md
@@ -54,6 +54,9 @@ compileMacOSBaseVQL:
 	./velosigmac compile --config ./config/macos_base_vql.yaml --output ./output/MacOS-Sigma-BaseVQL.zip --yaml ./output/MacOS.Sigma.BaseVQL.yaml --docs ./docs/content/docs/models/macos_base_vql/_index.md
 	./velosigmac compile --config ./config/macos_base_vql_test.yaml --yaml ./output/MacOS.Sigma.BaseVQL.CaptureTestSet.yaml
 	./velosigmac compile --config ./config/macos_base_vql_test_replay.yaml --yaml ./output/MacOS.Sigma.BaseVQL.ReplayTestSet.yaml
+
+compileMacOSTriage: compileMacOSBaseVQL
+	./velosigmac compile --config ./config/macos_sigma_triage.yaml --output ./output/MacOS-Sigma-Triage.zip --yaml ./output/MacOS.Sigma.Triage.yaml --rule_dir ./docs/content/docs/artifacts/MacOS.Sigma.Triage/ --docs ./docs/content/docs/artifacts/MacOS.Sigma.Triage/_index.md
 
 compileWindowsBaseVQL:
 	./velosigmac compile --config ./config/windows_base_vql.yaml --output ./output/Windows-Sigma-BaseVQL.zip --yaml ./output/Windows.Sigma.BaseVQL.yaml  --docs ./docs/content/docs/models/windows_base_vql/_index.md

--- a/config/macos_base_vql.yaml
+++ b/config/macos_base_vql.yaml
@@ -117,6 +117,16 @@ ExportTemplate: |
 
     LET Hostname <= dict(H={ SELECT Hostname FROM info()}).H[0].Hostname
 
+    LET _AllProcs <= SELECT Pid, Ppid, Name, Exe,
+          CommandLine, Username, CreateTime
+    FROM pslist()
+
+    LET _ProcLookup <= to_dict(item={
+      SELECT str(str=Pid) AS _key,
+             dict(Exe=Exe, CommandLine=CommandLine) AS _value
+      FROM _AllProcs
+    })
+
     {{ if .LogSources }}
     LET LogSources <= sigma_log_sources(
     {{ range .LogSources }}
@@ -147,6 +157,10 @@ FieldMappings:
   LastModified: "x=>x.EventData.LastModified"
   IndirectObjectIdentifier: "x=>x.EventData.IndirectObjectIdentifier"
   Flags: "x=>x.EventData.Flags"
+  Image: "x=>x.EventData.Image"
+  CommandLine: "x=>x.EventData.CommandLine"
+  ParentImage: "x=>x.EventData.ParentImage"
+  ParentCommandLine: "x=>x.EventData.ParentCommandLine"
 
 
 DefaultDetails:
@@ -228,6 +242,49 @@ Sources:
       - LastModified
       - IndirectObjectIdentifier
       - Flags
+
+  process_creation/macos/*:
+    description: |
+      Lists all running processes using pslist() and looks up each parent
+      process by Ppid. Returns one row per process.
+
+      This captures a snapshot at the time of collection, not a continuous
+      stream. Processes that start and stop quickly may not appear in the
+      results.
+
+      Unlike Windows (Event Logs) or Linux (auditd), macOS does not keep a
+      history of process creation. The Unified Log does not include command-line
+      arguments for executed processes.
+
+      Future work: 
+      - ESF-based real-time monitoring for event-stream coverage
+        similar to Windows ETW and Linux eBPF.
+      - Shell history (~/.zsh_history, ~/.bash_history) as a
+        complementary log source for historical interactive commands. Covers
+        typed commands with timestamps but not non-interactive processes
+        (LaunchDaemons, cron, GUI apps).
+
+    query: |
+      SELECT CreateTime AS Timestamp,
+             dict(Computer=Hostname, Channel='Velociraptor') AS System,
+             dict(
+               CreateTime=CreateTime,
+               CommandLine=CommandLine,
+               Image=Exe,
+               Pid=Pid,
+               ParentCommandLine=get(item=_ProcLookup,
+                   member=str(str=Ppid)).CommandLine,
+               ParentImage=get(item=_ProcLookup,
+                   member=str(str=Ppid)).Exe,
+               User=Username
+             ) AS EventData
+      FROM _AllProcs
+    fields:
+      - CommandLine
+      - Image
+      - ParentCommandLine
+      - ParentImage
+      - User
 
 QueryTemplate: |
  sources:

--- a/config/macos_base_vql.yaml
+++ b/config/macos_base_vql.yaml
@@ -117,16 +117,6 @@ ExportTemplate: |
 
     LET Hostname <= dict(H={ SELECT Hostname FROM info()}).H[0].Hostname
 
-    LET _AllProcs <= SELECT Pid, Ppid, Name, Exe,
-          CommandLine, Username, CreateTime
-    FROM pslist()
-
-    LET _ProcLookup <= to_dict(item={
-      SELECT str(str=Pid) AS _key,
-             dict(Exe=Exe, CommandLine=CommandLine) AS _value
-      FROM _AllProcs
-    })
-
     {{ if .LogSources }}
     LET LogSources <= sigma_log_sources(
     {{ range .LogSources }}
@@ -161,6 +151,8 @@ FieldMappings:
   CommandLine: "x=>x.EventData.CommandLine"
   ParentImage: "x=>x.EventData.ParentImage"
   ParentCommandLine: "x=>x.EventData.ParentCommandLine"
+  GrandParentImage: "x=>x.EventData.GrandParentImage"
+  GrandParentCommandLine: "x=>x.EventData.GrandParentCommandLine"
 
 
 DefaultDetails:
@@ -245,24 +237,12 @@ Sources:
 
   process_creation/macos/*:
     description: |
-      Lists all running processes using pslist() and looks up each parent
-      process by Ppid. Returns one row per process.
-
-      This captures a snapshot at the time of collection, not a continuous
-      stream. Processes that start and stop quickly may not appear in the
-      results.
-
-      Unlike Windows (Event Logs) or Linux (auditd), macOS does not keep a
-      history of process creation. The Unified Log does not include command-line
-      arguments for executed processes.
-
-      Future work: 
-      - ESF-based real-time monitoring for event-stream coverage
-        similar to Windows ETW and Linux eBPF.
-      - Shell history (~/.zsh_history, ~/.bash_history) as a
-        complementary log source for historical interactive commands. Covers
-        typed commands with timestamps but not non-interactive processes
-        (LaunchDaemons, cron, GUI apps).
+      Uses the Velociraptor process tracker to list processes and resolve
+      parent/grandparent call chains. When the process tracker is enabled (via a
+      client monitoring artifact), this includes historical processes that have
+      already exited. When the tracker is not enabled, process_tracker_pslist()
+      degrades to pslist() behaviour (snapshot of currently running processes
+      only), and parent/grandparent fields will be empty.
 
     query: |
       SELECT CreateTime AS Timestamp,
@@ -272,15 +252,24 @@ Sources:
                CommandLine=CommandLine,
                Image=Exe,
                Pid=Pid,
-               ParentCommandLine=get(item=_ProcLookup,
-                   member=str(str=Ppid)).CommandLine,
-               ParentImage=get(item=_ProcLookup,
-                   member=str(str=Ppid)).Exe,
+               ParentCommandLine=P.CommandLine,
+               ParentImage=P.Exe,
+               GrandParentCommandLine=GP.CommandLine,
+               GrandParentImage=GP.Exe,
                User=Username
              ) AS EventData
-      FROM _AllProcs
+      FROM foreach(row={
+        SELECT StartTime AS CreateTime,
+            Pid, CommandLine, Exe,
+            process_tracker_get(id=Ppid).Data AS P,
+            process_tracker_get(id=process_tracker_get(id=Ppid).ParentId).Data AS GP,
+            Username
+        FROM process_tracker_pslist()
+      })
     fields:
       - CommandLine
+      - GrandParentCommandLine
+      - GrandParentImage
       - Image
       - ParentCommandLine
       - ParentImage

--- a/config/macos_sigma_triage.yaml
+++ b/config/macos_sigma_triage.yaml
@@ -1,0 +1,103 @@
+Name: MacOS.Sigma.Triage
+ImportConfigs:
+  - config/macos_base_vql.yaml
+
+IncludeArtifacts:
+  - output/MacOS.Sigma.BaseVQL.yaml
+
+Preamble: |
+  name: MacOS.Sigma.Triage
+  description: |
+    This artifact compiles the macOS rules from SigmaHQ into a Velociraptor
+    artifact using the macOS Sigma Base model.
+
+    Currently covers process_creation rules only.
+
+    This artifact was built on {{ .Time }}
+
+  type: CLIENT
+
+  parameters:
+    - name: Debug
+      type: bool
+      description: Enable full debug trace
+
+    - name: RuleLevel
+      type: choices
+      default: All
+      choices:
+        - "Critical"
+        - "Critical and High"
+        - "Critical, High, and Medium"
+        - "All"
+
+    - name: RuleStatus
+      type: choices
+      default: All Rules
+      choices:
+        - Stable
+        - Stable and Experimental
+        - Stable and Test
+        - All Rules
+
+    - name: RuleTitleFilter
+      type: regex
+      default: .
+      description: Use this to filter only some rules to match
+
+    - name: RuleExclusions
+      type: csv
+      description: |
+        This table are rules that will be excluded by Title Regex
+      default: |
+        RuleTitleRegex,Reason
+        noisy,All rules marked noisy should be disabled by default.
+
+    - name: DateAfter
+      description: "search for events after this date. YYYY-MM-DDTmm:hh:ss Z"
+      type: timestamp
+
+    - name: DateBefore
+      description: "search for events before this date. YYYY-MM-DDTmm:hh:ss Z"
+      type: timestamp
+
+  imports:
+    - MacOS.Sigma.BaseVQL
+
+QueryTemplate: |
+   sources:
+   - query: |
+       LET Rules <= gunzip(string=base64decode(string="{{.Base64CompressedRules}}"))
+       SELECT *
+       FROM Artifact.MacOS.Sigma.BaseVQL(
+          RuleLevel=RuleLevel, RuleStatus=RuleStatus,
+          RuleTitleFilter=RuleTitleFilter, Debug=Debug,
+          RuleExclusions=RuleExclusions,
+          DateAfter=DateAfter, DateBefore=DateBefore,
+          SigmaRules=Rules)
+
+RuleDirectories:
+  - rules/sigma/rules/macos/process_creation/
+
+DocTemplate: |
+  ---
+  title: MacOS.Sigma.Triage
+  weight: 20
+  bookToc: false
+  IconClass: fa-solid fa-book
+  ---
+
+  # MacOS.Sigma.Triage artifact
+
+  This artifact compiles the macOS rules from SigmaHQ into a Velociraptor
+  artifact using the macOS Sigma Base model. Currently covers process_creation
+  rules only.
+
+  Base Artifact: [MacOS.Sigma.BaseVQL](/docs/models/macos_base_vql/)
+
+  You can download the artifact pack here
+  [MacOS-Sigma-Triage.zip](/artifacts/MacOS-Sigma-Triage.zip)
+  and customize using instructions at
+  [Customizing Artifacts](https://sigma.velocidex.com/docs/sigma_in_velociraptor/customize/)
+
+  {{ "{{< ruleset \"index.json\" >}}" }}

--- a/tests/testcases/fixtures/macos_pslist_process.json
+++ b/tests/testcases/fixtures/macos_pslist_process.json
@@ -1,2 +1,2 @@
-[{"Pid": 1234, "Ppid": 567, "Name": "base64", "Exe": "/usr/bin/base64", "CommandLine": "/usr/bin/base64 -d /tmp/payload.enc", "Username": "admin", "CreateTime": "2025-06-15T09:00:00Z"},
-{"Pid": 567, "Ppid": 1, "Name": "bash", "Exe": "/bin/bash", "CommandLine": "/bin/bash -c /usr/bin/base64 -d /tmp/payload.enc", "Username": "admin", "CreateTime": "2025-06-15T08:55:00Z"}]
+[{"Pid": 99992, "Ppid": 99991, "Name": "base64", "Exe": "/usr/bin/base64", "CommandLine": "/usr/bin/base64 -d /tmp/payload.enc", "Username": "admin", "StartTime": "2025-06-15T09:00:00Z"},
+{"Pid": 99991, "Ppid": 99990, "Name": "bash", "Exe": "/bin/bash", "CommandLine": "/bin/bash -c /usr/bin/base64 -d /tmp/payload.enc", "Username": "admin", "StartTime": "2025-06-15T08:55:00Z"}]

--- a/tests/testcases/fixtures/macos_pslist_process.json
+++ b/tests/testcases/fixtures/macos_pslist_process.json
@@ -1,0 +1,2 @@
+[{"Pid": 1234, "Ppid": 567, "Name": "base64", "Exe": "/usr/bin/base64", "CommandLine": "/usr/bin/base64 -d /tmp/payload.enc", "Username": "admin", "CreateTime": "2025-06-15T09:00:00Z"},
+{"Pid": 567, "Ppid": 1, "Name": "bash", "Exe": "/bin/bash", "CommandLine": "/bin/bash -c /usr/bin/base64 -d /tmp/payload.enc", "Username": "admin", "CreateTime": "2025-06-15T08:55:00Z"}]

--- a/tests/testcases/macos_pslist.in.yaml
+++ b/tests/testcases/macos_pslist.in.yaml
@@ -16,6 +16,6 @@ Parameters:
 Queries:
 - LET _ <= SELECT mock(plugin='info', results=[dict(Hostname="test-mac.local", OS="darwin"),]) FROM scope()
 
-- LET _ <= SELECT mock(plugin='pslist', results=parse_json_array(data=read_file(filename=testDir + PslistRows))) FROM scope()
+- LET _ <= SELECT mock(plugin='process_tracker_pslist', results=parse_json_array(data=read_file(filename=testDir + PslistRows))) FROM scope()
 
 - SELECT * FROM Artifact.MacOS.Sigma.BaseVQL(SigmaRules=SigmaRule, RuleLevel='All', RuleStatus='All Rules') LIMIT 1

--- a/tests/testcases/macos_pslist.in.yaml
+++ b/tests/testcases/macos_pslist.in.yaml
@@ -1,0 +1,21 @@
+Parameters:
+  PslistRows: /testcases/fixtures/macos_pslist_process.json
+  SigmaRule: |
+    title: Base64 Decode Detected
+    status: test
+    logsource:
+      category: process_creation
+      product: macos
+    detection:
+      selection:
+        Image|endswith: '/base64'
+        CommandLine|contains: '-d'
+      condition: selection
+    level: critical
+
+Queries:
+- LET _ <= SELECT mock(plugin='info', results=[dict(Hostname="test-mac.local", OS="darwin"),]) FROM scope()
+
+- LET _ <= SELECT mock(plugin='pslist', results=parse_json_array(data=read_file(filename=testDir + PslistRows))) FROM scope()
+
+- SELECT * FROM Artifact.MacOS.Sigma.BaseVQL(SigmaRules=SigmaRule, RuleLevel='All', RuleStatus='All Rules') LIMIT 1

--- a/tests/testcases/macos_pslist.out.yaml
+++ b/tests/testcases/macos_pslist.out.yaml
@@ -1,7 +1,7 @@
 Query: LET _ <= SELECT mock(plugin='info', results=[dict(Hostname="test-mac.local", OS="darwin"),]) FROM scope()
 Output: []
 
-Query: LET _ <= SELECT mock(plugin='pslist', results=parse_json_array(data=read_file(filename=testDir + PslistRows))) FROM scope()
+Query: LET _ <= SELECT mock(plugin='process_tracker_pslist', results=parse_json_array(data=read_file(filename=testDir + PslistRows))) FROM scope()
 Output: []
 
 Query: SELECT * FROM Artifact.MacOS.Sigma.BaseVQL(SigmaRules=SigmaRule, RuleLevel='All', RuleStatus='All Rules') LIMIT 1
@@ -16,9 +16,11 @@ Output: [
    "CreateTime": "2025-06-15T09:00:00Z",
    "CommandLine": "/usr/bin/base64 -d /tmp/payload.enc",
    "Image": "/usr/bin/base64",
-   "Pid": 1234,
-   "ParentCommandLine": "/bin/bash -c /usr/bin/base64 -d /tmp/payload.enc",
-   "ParentImage": "/bin/bash",
+   "Pid": 99992,
+   "ParentCommandLine": null,
+   "ParentImage": null,
+   "GrandParentCommandLine": null,
+   "GrandParentImage": null,
    "User": "admin"
   },
   "_Event": {
@@ -30,9 +32,11 @@ Output: [
     "CreateTime": "2025-06-15T09:00:00Z",
     "CommandLine": "/usr/bin/base64 -d /tmp/payload.enc",
     "Image": "/usr/bin/base64",
-    "Pid": 1234,
-    "ParentCommandLine": "/bin/bash -c /usr/bin/base64 -d /tmp/payload.enc",
-    "ParentImage": "/bin/bash",
+    "Pid": 99992,
+    "ParentCommandLine": null,
+    "ParentImage": null,
+    "GrandParentCommandLine": null,
+    "GrandParentImage": null,
     "User": "admin"
    },
    "Message": null

--- a/tests/testcases/macos_pslist.out.yaml
+++ b/tests/testcases/macos_pslist.out.yaml
@@ -1,0 +1,44 @@
+Query: LET _ <= SELECT mock(plugin='info', results=[dict(Hostname="test-mac.local", OS="darwin"),]) FROM scope()
+Output: []
+
+Query: LET _ <= SELECT mock(plugin='pslist', results=parse_json_array(data=read_file(filename=testDir + PslistRows))) FROM scope()
+Output: []
+
+Query: SELECT * FROM Artifact.MacOS.Sigma.BaseVQL(SigmaRules=SigmaRule, RuleLevel='All', RuleStatus='All Rules') LIMIT 1
+Output: [
+ {
+  "Timestamp": "2025-06-15T09:00:00Z",
+  "Computer": "test-mac.local",
+  "Channel": "Velociraptor",
+  "Level": "critical",
+  "Title": "Base64 Decode Detected",
+  "Details": {
+   "CreateTime": "2025-06-15T09:00:00Z",
+   "CommandLine": "/usr/bin/base64 -d /tmp/payload.enc",
+   "Image": "/usr/bin/base64",
+   "Pid": 1234,
+   "ParentCommandLine": "/bin/bash -c /usr/bin/base64 -d /tmp/payload.enc",
+   "ParentImage": "/bin/bash",
+   "User": "admin"
+  },
+  "_Event": {
+   "System": {
+    "Computer": "test-mac.local",
+    "Channel": "Velociraptor"
+   },
+   "EventData": {
+    "CreateTime": "2025-06-15T09:00:00Z",
+    "CommandLine": "/usr/bin/base64 -d /tmp/payload.enc",
+    "Image": "/usr/bin/base64",
+    "Pid": 1234,
+    "ParentCommandLine": "/bin/bash -c /usr/bin/base64 -d /tmp/payload.enc",
+    "ParentImage": "/bin/bash",
+    "User": "admin"
+   },
+   "Message": null
+  },
+  "Enrichment": null,
+  "_Source": "MacOS.Sigma.BaseVQL"
+ }
+]
+

--- a/tests/testcases/macos_triage.in.yaml
+++ b/tests/testcases/macos_triage.in.yaml
@@ -4,6 +4,6 @@ Parameters:
 Queries:
 - LET _ <= SELECT mock(plugin='info', results=[dict(Hostname="test-mac.local", OS="darwin"),]) FROM scope()
 
-- LET _ <= SELECT mock(plugin='pslist', results=parse_json_array(data=read_file(filename=testDir + PslistRows))) FROM scope()
+- LET _ <= SELECT mock(plugin='process_tracker_pslist', results=parse_json_array(data=read_file(filename=testDir + PslistRows))) FROM scope()
 
 - SELECT * FROM Artifact.MacOS.Sigma.Triage(RuleLevel='All', RuleStatus='All Rules') ORDER BY Title LIMIT 1

--- a/tests/testcases/macos_triage.in.yaml
+++ b/tests/testcases/macos_triage.in.yaml
@@ -1,0 +1,9 @@
+Parameters:
+  PslistRows: /testcases/fixtures/macos_pslist_process.json
+
+Queries:
+- LET _ <= SELECT mock(plugin='info', results=[dict(Hostname="test-mac.local", OS="darwin"),]) FROM scope()
+
+- LET _ <= SELECT mock(plugin='pslist', results=parse_json_array(data=read_file(filename=testDir + PslistRows))) FROM scope()
+
+- SELECT * FROM Artifact.MacOS.Sigma.Triage(RuleLevel='All', RuleStatus='All Rules') ORDER BY Title LIMIT 1

--- a/tests/testcases/macos_triage.out.yaml
+++ b/tests/testcases/macos_triage.out.yaml
@@ -1,0 +1,44 @@
+Query: LET _ <= SELECT mock(plugin='info', results=[dict(Hostname="test-mac.local", OS="darwin"),]) FROM scope()
+Output: []
+
+Query: LET _ <= SELECT mock(plugin='pslist', results=parse_json_array(data=read_file(filename=testDir + PslistRows))) FROM scope()
+Output: []
+
+Query: SELECT * FROM Artifact.MacOS.Sigma.Triage(RuleLevel='All', RuleStatus='All Rules') ORDER BY Title LIMIT 1
+Output: [
+ {
+  "Timestamp": "2025-06-15T09:00:00Z",
+  "Computer": "test-mac.local",
+  "Channel": "Velociraptor",
+  "Level": "low",
+  "Title": "Decode Base64 Encoded Text -MacOs",
+  "Details": {
+   "CreateTime": "2025-06-15T09:00:00Z",
+   "CommandLine": "/usr/bin/base64 -d /tmp/payload.enc",
+   "Image": "/usr/bin/base64",
+   "Pid": 1234,
+   "ParentCommandLine": "/bin/bash -c /usr/bin/base64 -d /tmp/payload.enc",
+   "ParentImage": "/bin/bash",
+   "User": "admin"
+  },
+  "_Event": {
+   "System": {
+    "Computer": "test-mac.local",
+    "Channel": "Velociraptor"
+   },
+   "EventData": {
+    "CreateTime": "2025-06-15T09:00:00Z",
+    "CommandLine": "/usr/bin/base64 -d /tmp/payload.enc",
+    "Image": "/usr/bin/base64",
+    "Pid": 1234,
+    "ParentCommandLine": "/bin/bash -c /usr/bin/base64 -d /tmp/payload.enc",
+    "ParentImage": "/bin/bash",
+    "User": "admin"
+   },
+   "Message": null
+  },
+  "Enrichment": null,
+  "_Source": "MacOS.Sigma.Triage"
+ }
+]
+

--- a/tests/testcases/macos_triage.out.yaml
+++ b/tests/testcases/macos_triage.out.yaml
@@ -1,7 +1,7 @@
 Query: LET _ <= SELECT mock(plugin='info', results=[dict(Hostname="test-mac.local", OS="darwin"),]) FROM scope()
 Output: []
 
-Query: LET _ <= SELECT mock(plugin='pslist', results=parse_json_array(data=read_file(filename=testDir + PslistRows))) FROM scope()
+Query: LET _ <= SELECT mock(plugin='process_tracker_pslist', results=parse_json_array(data=read_file(filename=testDir + PslistRows))) FROM scope()
 Output: []
 
 Query: SELECT * FROM Artifact.MacOS.Sigma.Triage(RuleLevel='All', RuleStatus='All Rules') ORDER BY Title LIMIT 1
@@ -16,9 +16,11 @@ Output: [
    "CreateTime": "2025-06-15T09:00:00Z",
    "CommandLine": "/usr/bin/base64 -d /tmp/payload.enc",
    "Image": "/usr/bin/base64",
-   "Pid": 1234,
-   "ParentCommandLine": "/bin/bash -c /usr/bin/base64 -d /tmp/payload.enc",
-   "ParentImage": "/bin/bash",
+   "Pid": 99992,
+   "ParentCommandLine": null,
+   "ParentImage": null,
+   "GrandParentCommandLine": null,
+   "GrandParentImage": null,
    "User": "admin"
   },
   "_Event": {
@@ -30,9 +32,11 @@ Output: [
     "CreateTime": "2025-06-15T09:00:00Z",
     "CommandLine": "/usr/bin/base64 -d /tmp/payload.enc",
     "Image": "/usr/bin/base64",
-    "Pid": 1234,
-    "ParentCommandLine": "/bin/bash -c /usr/bin/base64 -d /tmp/payload.enc",
-    "ParentImage": "/bin/bash",
+    "Pid": 99992,
+    "ParentCommandLine": null,
+    "ParentImage": null,
+    "GrandParentCommandLine": null,
+    "GrandParentImage": null,
     "User": "admin"
    },
    "Message": null


### PR DESCRIPTION
- Added process_creation log source to MacOS.Sigma.BaseVQL so SigmaHQ process_creation rules can be compiled
- Added MacOS.Sigma.Triage config with SigmaHQ macos process_creation rules
- Added compileMacOSTriage Makefile target (depends on compileMacOSBaseVQL)
- Added golden tests for BaseVQL process_creation and Triage artifact