### PR TITLE
T1016 prefetch correlation

### DIFF
--- a/config/windows_base_vql.yaml
+++ b/config/windows_base_vql.yaml
@@ -212,6 +212,28 @@ Sources:
       - Timestamp
       - EventData
       - System
+    
+  /windows/prefetch:
+    description: |
+      Prefetch entries via Velociraptor artifacts. Emits one event per .PF file,
+      using the Prefetch file mtime as Timestamp and exposing the executable name
+      for Sigma matching.
+    query: |
+      SELECT
+        modified AS Timestamp,
+        dict(Computer=Hostname, Channel='Velociraptor') AS System,
+        dict(
+          PrefetchName = Name,                                  -- e.g. RUNDLL32.EXE-81640945.pf
+          Image        = regex_replace(source=Name, re='-.*$', replace=''),  -- RUNDLL32.EXE
+          OSPath       = format(format='C:\\Windows\\Prefetch\\%v', args=[Name]),
+          Mtime        = modified
+        ) AS EventData
+      FROM Artifact.Windows.Attack.Prefetch()
+    fields:
+      - Image
+      - Name
+      - OSPath
+      - Mtime
 
   filesystem/windows/glob:
     description: |
@@ -232,6 +254,31 @@ Sources:
       - OSPath
       - Size
       - Mtime
+
+
+    # Evidence of execution from Prefetch files
+  /windows/prefetch:
+    description: |
+      Prefetch entries via Velociraptor artifacts. Emits one event per .PF file,
+      using the Prefetch file mtime as Timestamp and exposing the executable name
+      for Sigma matching.
+    query: |
+      SELECT
+        modified AS Timestamp,
+        dict(Computer=Hostname, Channel='Velociraptor') AS System,
+        dict(
+          PrefetchName = Name,                                  -- e.g. RUNDLL32.EXE-81640945.pf
+          Image        = regex_replace(source=Name, re='-.*$', replace=''),  -- RUNDLL32.EXE
+          OSPath       = format(format='C:\\Windows\\Prefetch\\%v', args=[Name]),
+          Mtime        = modified
+        ) AS EventData
+      FROM Artifact.Windows.Attack.Prefetch()
+    fields:
+      - Image
+      - Name
+      - OSPath
+      - Mtime
+  
 
   process_creation/windows/pslist:
     query: |

--- a/config/windows_base_vql.yaml
+++ b/config/windows_base_vql.yaml
@@ -247,30 +247,6 @@ Sources:
       - Mtime
 
 
-    # Evidence of execution from Prefetch files
-  /windows/prefetch:
-    description: |
-      Prefetch entries via Velociraptor artifacts. Emits one event per .PF file,
-      using the Prefetch file mtime as Timestamp and exposing the executable name
-      for Sigma matching.
-    query: |
-      SELECT
-        modified AS Timestamp,
-        dict(Computer=Hostname, Channel='Velociraptor') AS System,
-        dict(
-          PrefetchName = Name,                                  -- e.g. RUNDLL32.EXE-81640945.pf
-          Image        = regex_replace(source=Name, re='-.*$', replace=''),  -- RUNDLL32.EXE
-          OSPath       = format(format='C:\\Windows\\Prefetch\\%v', args=[Name]),
-          Mtime        = modified
-        ) AS EventData
-      FROM Artifact.Windows.Attack.Prefetch()
-    fields:
-      - Image
-      - Name
-      - OSPath
-      - Mtime
-  
-
   process_creation/windows/pslist:
     query: |
       SELECT CreateTime AS Timestamp,

--- a/config/windows_base_vql.yaml
+++ b/config/windows_base_vql.yaml
@@ -212,28 +212,19 @@ Sources:
       - Timestamp
       - EventData
       - System
-    
-  /windows/prefetch:
-    description: |
-      Prefetch entries via Velociraptor artifacts. Emits one event per .PF file,
-      using the Prefetch file mtime as Timestamp and exposing the executable name
-      for Sigma matching.
+
+  process_creation/windows/attack_prefetch:
     query: |
       SELECT
         modified AS Timestamp,
         dict(Computer=Hostname, Channel='Velociraptor') AS System,
         dict(
-          PrefetchName = Name,                                  -- e.g. RUNDLL32.EXE-81640945.pf
-          Image        = regex_replace(source=Name, re='-.*$', replace=''),  -- RUNDLL32.EXE
-          OSPath       = format(format='C:\\Windows\\Prefetch\\%v', args=[Name]),
-          Mtime        = modified
+          Name=Name,
+          Mtime=modified,
+          ModTime=ModTime,
+          Image=split(string=Name, sep='-')[0]
         ) AS EventData
       FROM Artifact.Windows.Attack.Prefetch()
-    fields:
-      - Image
-      - Name
-      - OSPath
-      - Mtime
 
   filesystem/windows/glob:
     description: |

--- a/config/windows_base_vql.yaml
+++ b/config/windows_base_vql.yaml
@@ -225,6 +225,15 @@ Sources:
           Image=split(string=Name, sep='-')[0]
         ) AS EventData
       FROM Artifact.Windows.Attack.Prefetch()
+    fields:
+      - Timestamp
+      - Image
+      - Name
+      - Mtime
+      - ModTime
+      - System.Computer
+      - System.Channel
+
 
   filesystem/windows/glob:
     description: |

--- a/config/windows_base_vql.yaml
+++ b/config/windows_base_vql.yaml
@@ -638,7 +638,7 @@ QueryTemplate: |
           dict(System=System,
                EventData=X.EventData || X.UserData,
                Message=X.Message) AS _Event,
-          _Match, *
+          X._Match || X._Correlations AS _Match, *
     FROM sigma(
       rules=split(string=SigmaRules, sep="\n---+\r?\n"),
       log_sources= LogSources, debug=Debug,

--- a/rules/vql/windows/t1016_network_discovery_utility_burst_prefetch.yml
+++ b/rules/vql/windows/t1016_network_discovery_utility_burst_prefetch.yml
@@ -71,11 +71,9 @@ level: medium
 title: T1016 Multiple Rare Network Discovery Tools In Prefetch
 name: t1016_prefetch_rare_tools_count
 status: experimental
-description: Detects two or more distinct rare network or domain discovery utilities in Prefetch within five minutes.
-logsource:
-  category: forensics
-  product: windows
-  service: prefetch
+description: |
+  Detects two or more distinct rare network or domain discovery
+  utilities in Prefetch within five minutes.
 correlation:
   type: value_count
   rules:
@@ -87,4 +85,3 @@ correlation:
     field: Image
     gte: 2
 level: medium
-

--- a/rules/vql/windows/t1016_network_discovery_utility_burst_prefetch.yml
+++ b/rules/vql/windows/t1016_network_discovery_utility_burst_prefetch.yml
@@ -1,0 +1,90 @@
+title: T1016 Core Network Discovery Tools In Prefetch
+name: t1016_prefetch_core_tools
+status: experimental
+description: Detects execution evidence of common Windows network discovery utilities from Prefetch.
+references:
+  - https://attack.mitre.org/techniques/T1016/
+tags:
+  - attack.discovery
+  - attack.t1016
+logsource:
+  category: forensics
+  product: windows
+  service: prefetch
+detection:
+  selection:
+    Image|contains:
+      - ipconfig
+      - arp
+      - route
+      - netstat
+      - nbtstat
+      - netsh
+      - nslookup
+      - nltest
+  condition: selection
+level: low
+---
+title: T1016 Rare Network Discovery Tools In Prefetch
+name: t1016_prefetch_rare_tools
+status: experimental
+description: Detects execution evidence of less common Windows network or domain discovery utilities from Prefetch.
+references:
+  - https://attack.mitre.org/techniques/T1016/
+tags:
+  - attack.discovery
+  - attack.t1016
+logsource:
+  category: forensics
+  product: windows
+  service: prefetch
+detection:
+  selection:
+    Image|contains:
+      - netsh
+      - nltest
+      - nslookup
+      - nbtstat
+  condition: selection
+level: low
+---
+title: T1016 Multiple Core Network Discovery Tools In Prefetch
+name: t1016_prefetch_core_tools_count
+status: experimental
+description: Detects four or more distinct core network discovery utilities in Prefetch within five minutes.
+logsource:
+  category: forensics
+  product: windows
+  service: prefetch
+correlation:
+  type: value_count
+  rules:
+    - t1016_prefetch_core_tools
+  group-by:
+    - System.Computer
+  timespan: 5m
+  condition:
+    field: Image
+    gte: 4
+level: medium
+---
+title: T1016 Multiple Rare Network Discovery Tools In Prefetch
+name: t1016_prefetch_rare_tools_count
+status: experimental
+description: Detects two or more distinct rare network or domain discovery utilities in Prefetch within five minutes.
+logsource:
+  category: forensics
+  product: windows
+  service: prefetch
+correlation:
+  type: value_count
+  rules:
+    - t1016_prefetch_rare_tools
+  group-by:
+    - System.Computer
+  timespan: 5m
+  condition:
+    field: Image
+    gte: 2
+level: medium
+

--- a/src/compile.go
+++ b/src/compile.go
@@ -151,12 +151,13 @@ func (self *CompilerContext) CompileRule(rule_yaml, path string) error {
 
 	// This is the concise and reducted rule that will be hunted for.
 	new_rule := sigma.Rule{
-		Title:     rule.Title,
-		Author:    rule.Author,
-		Level:     rule.Level,
-		Status:    rule.Status,
-		Logsource: rule.Logsource,
-		Detection: self.normalize_detections(rule.Detection),
+		Title:       rule.Title,
+		Author:      rule.Author,
+		Level:       rule.Level,
+		Status:      rule.Status,
+		Logsource:   rule.Logsource,
+		Detection:   self.normalize_detections(rule.Detection),
+		Correlation: rule.Correlation,
 		//Detection:        rule.Detection,
 		AdditionalFields: additional_fields,
 	}
@@ -193,7 +194,7 @@ func (self *CompilerContext) CompileRule(rule_yaml, path string) error {
 	}
 
 	DebugPrint("Processing %v\n", path)
-	self.rules = append(self.rules, string(buf.Bytes()))
+	self.rules = append(self.rules, buf.String())
 
 	self.incLogSource(logsource)
 

--- a/src/logsources.go
+++ b/src/logsources.go
@@ -507,6 +507,12 @@ func (self *CompilerContext) walk_fields(
 
 func (self *CompilerContext) normalize_logsource(
 	rule *sigma.Rule, path string) (string, error) {
+
+	// Correlation rules are allowed to not have a logsource
+	if rule.Correlation != nil {
+		return "", nil
+	}
+
 	source := rule.Logsource
 	category := source.Category
 	if category == "" {
@@ -539,6 +545,7 @@ func (self *CompilerContext) normalize_logsource(
 		return source_spec, nil
 
 	}
+
 	// Try to guess the source spec
 	DebugPrint("**** Log Source '%v' not found!\n", guessed_source_spec)
 	return source_spec, fmt.Errorf(

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,12 @@
+checks = ["all",
+         #  error strings should not be capitalized (ST1005)
+         "-ST1005",
+         # receiver name should be a reflection of its identity
+         "-ST1006",
+         # should not use underscores in Go names
+         "-ST1003",
+         # at least one file in a package should have a package comment
+         "-ST1000",
+         # the surrounding loop is unconditionally terminated
+         "-SA4004",
+         ]


### PR DESCRIPTION

This PR adds Windows Sigma/VQL triage rules for MITRE ATT&CK T1016 Network Discovery using the existing `forensics/windows/prefetch` logsource.

The new rule set includes:

- Core network discovery tools in Prefetch
- Rare network/domain discovery tools in Prefetch
- A `value_count` correlation for 4 or more distinct core tools within 5 minutes
- A `value_count` correlation for 2 or more distinct rare tools within 5 minutes

## BaseVQL change

This PR also updates `windows_base_vql.yaml` so correlation results that emit `_Correlations` are supported alongside normal Sigma hits that emit `_Match`.

## Testing

Tested in a Windows VM using Atomic Red Team T1016.

Confirmed hits for:

- `T1016 Multiple Core Network Discovery Tools In Prefetch`
- `T1016 Multiple Rare Network Discovery Tools In Prefetch`

The previous `_Match not found` warning was resolved after the BaseVQL change.